### PR TITLE
Implement database-backed authentication in backend_site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ frontend/node_modules
 __pycache__/
 *.pyc
 
+# Databases
+*.db
+
 # Build outputs
 frontend/dist
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] Implement authentication in `backend_site`.
+- [x] Implement authentication in `backend_site`.
 - [ ] Add OCR processing pipeline in `backend_ia`.
 - [ ] Define API between `backend_site` and `backend_ia` for submitting sheet
       images, game state, and legal moves and returning candidate moves with

--- a/backend_site/app/db.py
+++ b/backend_site/app/db.py
@@ -1,0 +1,43 @@
+import os
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "sqlite:///./app.db",  # Local file for dev/test; override in production
+)
+
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    games = relationship("ChessGame", back_populates="owner")
+
+
+class ChessGame(Base):
+    __tablename__ = "games"
+
+    id = Column(Integer, primary_key=True, index=True)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    pgn = Column(String, nullable=False)
+    owner = relationship("User", back_populates="games")
+
+
+def init_db() -> None:
+    Base.metadata.create_all(bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend_site/app/main.py
+++ b/backend_site/app/main.py
@@ -1,8 +1,38 @@
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from passlib.context import CryptContext
+from sqlalchemy.orm import Session
+
+from .db import User, get_db, init_db
 
 app = FastAPI()
+security = HTTPBasic()
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+init_db()
+
+
+def get_current_username(
+    credentials: HTTPBasicCredentials = Depends(security),
+    db: Session = Depends(get_db),
+) -> str:
+    """Validate basic auth credentials against the database."""
+    user = db.query(User).filter_by(username=credentials.username).first()
+    if not user or not pwd_context.verify(credentials.password, user.password_hash):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Incorrect username or password",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return user.username
 
 
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/secure")
+async def secure(username: str = Depends(get_current_username)) -> dict[str, str]:
+    """An endpoint protected by basic authentication."""
+    return {"hello": username}

--- a/backend_site/requirements.txt
+++ b/backend_site/requirements.txt
@@ -2,3 +2,6 @@ fastapi
 uvicorn[standard]
 pytest
 httpx
+sqlalchemy
+psycopg2-binary
+passlib[bcrypt]

--- a/backend_site/tests/test_auth.py
+++ b/backend_site/tests/test_auth.py
@@ -1,0 +1,61 @@
+import os
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from app.db import Base, ChessGame, User, get_db  # noqa: E402
+from app.main import app, pwd_context  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    TestingSessionLocal = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+
+    def override_get_db():
+        db = TestingSessionLocal()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with TestingSessionLocal() as db:
+        user = User(username="admin", password_hash=pwd_context.hash("secret"))
+        db.add(user)
+        db.add(ChessGame(owner=user, pgn="1. e4 e5"))
+        db.commit()
+
+    with TestClient(app) as c:
+        c.session_maker = TestingSessionLocal
+        yield c
+
+    app.dependency_overrides.clear()
+
+
+def test_auth_required(client):
+    response = client.get("/secure")
+    assert response.status_code == 401
+
+
+def test_auth_success(client):
+    response = client.get("/secure", auth=("admin", "secret"))
+    assert response.json() == {"hello": "admin"}
+
+
+def test_user_has_game(client):
+    with client.session_maker() as db:
+        user = db.query(User).filter_by(username="admin").first()
+        assert user.games[0].pgn.startswith("1. e4")


### PR DESCRIPTION
## Summary
- rename default SQLite database to `app.db` and document `DATABASE_URL` for production
- add `ChessGame` model linked to `User` for future game tracking
- extend authentication tests to seed a game and verify user-game association

## Testing
- `cd backend_site && pip install -r requirements.txt`
- `cd backend_site && pytest`


------
https://chatgpt.com/codex/tasks/task_e_689733c54050832eb46d7ba91833be9c