### PR TITLE
feat: add Pinia store with email auth and Google sign-in

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "chessocr-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "pinia": "^2.3.1",
         "vue": "^3.4.0",
         "vue-router": "^4.2.0"
       },
@@ -657,6 +658,28 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/pinia": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.3.1.tgz",
+      "integrity": "sha512-khUlZSwt9xXCaTbbxFYBKDc/bWAGWJjOgvxETwkTN7KRm66EeT1ZdZj6i2ceh9sP2Pzqsbc704r2yngBrxBVug==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.4.4",
+        "vue": "^2.7.0 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -784,6 +807,32 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "test": "echo \"No tests yet\""
   },
   "dependencies": {
+    "pinia": "^2.3.1",
     "vue": "^3.4.0",
     "vue-router": "^4.2.0"
   },

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -14,9 +14,10 @@
 <script setup>
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
-import { store } from '../store';
+import { useUserStore } from '../store';
 
 const router = useRouter();
+const store = useUserStore();
 const open = ref(false);
 function toggle() {
   open.value = !open.value;

--- a/frontend/src/components/SignIn.vue
+++ b/frontend/src/components/SignIn.vue
@@ -1,33 +1,39 @@
 <template>
-  <div class="max-w-sm mx-auto mt-10">
+  <div class="max-w-sm mx-auto mt-10 space-y-2">
     <form @submit.prevent="submit" class="space-y-2">
-      <input v-model="username" class="border p-2 w-full" placeholder="Username" />
-      <input v-model="password" type="password" class="border p-2 w-full" placeholder="Password" />
-      <button type="submit" class="bg-blue-500 text-white px-4 py-2">Sign In</button>
+      <input v-model="email" type="email" required class="border p-2 w-full" placeholder="Email" />
+      <input v-model="password" type="password" required class="border p-2 w-full" placeholder="Password" />
+      <button type="submit" class="bg-blue-500 text-white px-4 py-2 w-full">Sign In</button>
     </form>
+    <button @click="google" class="bg-red-500 text-white px-4 py-2 w-full">Sign in with Google</button>
   </div>
 </template>
 
 <script setup>
 import { ref } from 'vue';
 import { useRouter } from 'vue-router';
-import { store } from '../store';
+import { useUserStore } from '../store';
 
-const username = ref('');
+const email = ref('');
 const password = ref('');
 const router = useRouter();
+const store = useUserStore();
 
 async function submit() {
   const res = await fetch('/login', {
     headers: {
-      'Authorization': 'Basic ' + btoa(username.value + ':' + password.value)
+      'Authorization': 'Basic ' + btoa(email.value + ':' + password.value)
     }
   });
   if (res.ok) {
-    store.user = username.value;
+    store.user = email.value;
     router.push('/');
   } else {
     alert('Login failed');
   }
+}
+
+function google() {
+  window.location.href = '/auth/google';
 }
 </script>

--- a/frontend/src/components/SignUp.vue
+++ b/frontend/src/components/SignUp.vue
@@ -1,9 +1,10 @@
 <template>
   <div class="max-w-sm mx-auto mt-10">
     <form @submit.prevent="submit" class="space-y-2">
-      <input v-model="username" class="border p-2 w-full" placeholder="Username" />
-      <input v-model="password" type="password" class="border p-2 w-full" placeholder="Password" />
-      <button type="submit" class="bg-green-500 text-white px-4 py-2">Sign Up</button>
+      <input v-model="username" required class="border p-2 w-full" placeholder="Username" />
+      <input v-model="email" type="email" required class="border p-2 w-full" placeholder="Email" />
+      <input v-model="password" type="password" required class="border p-2 w-full" placeholder="Password" />
+      <button type="submit" class="bg-green-500 text-white px-4 py-2 w-full">Sign Up</button>
     </form>
   </div>
 </template>
@@ -11,12 +12,14 @@
 <script setup>
 import { ref } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
-import { store } from '../store';
+import { useUserStore } from '../store';
 
 const username = ref('');
+const email = ref('');
 const password = ref('');
 const router = useRouter();
 const route = useRoute();
+const store = useUserStore();
 const refCode = route.query.ref || '';
 
 async function submit() {
@@ -25,6 +28,7 @@ async function submit() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       username: username.value,
+      email: email.value,
       password: password.value,
       referral_code: refCode || null
     })
@@ -32,11 +36,11 @@ async function submit() {
   if (res.ok) {
     const loginRes = await fetch('/login', {
       headers: {
-        'Authorization': 'Basic ' + btoa(username.value + ':' + password.value)
+        'Authorization': 'Basic ' + btoa(email.value + ':' + password.value)
       }
     });
     if (loginRes.ok) {
-      store.user = username.value;
+      store.user = email.value;
       router.push('/');
     }
   } else {

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,5 +1,9 @@
 import { createApp } from 'vue';
+import { createPinia } from 'pinia';
 import App from './App.vue';
 import { router } from './router';
 
-createApp(App).use(router).mount('#app');
+const app = createApp(App);
+app.use(createPinia());
+app.use(router);
+app.mount('#app');

--- a/frontend/src/store.js
+++ b/frontend/src/store.js
@@ -1,5 +1,7 @@
-import { reactive } from 'vue';
+import { defineStore } from 'pinia';
 
-export const store = reactive({
-  user: null
+export const useUserStore = defineStore('user', {
+  state: () => ({
+    user: null
+  })
 });


### PR DESCRIPTION
## Summary
- add Pinia store for user state
- require email for sign-up and sign-in, with Google OAuth option

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68975398078c832eacbb4872d1dcaaa1