### PR TITLE
Replace OCR pipeline with placeholder IA

### DIFF
--- a/backend_ia/service/main.py
+++ b/backend_ia/service/main.py
@@ -1,6 +1,30 @@
+class MoveModel:
+    """Placeholder model handling training and inference."""
+
+    def train(self, data_path: str) -> None:
+        """Placeholder for training logic."""
+        # Training implementation will be added later
+        pass
+
+    def save(self, path: str) -> None:
+        """Placeholder for saving model weights."""
+        pass
+
+    def load(self, path: str) -> None:
+        """Placeholder for loading model weights."""
+        pass
+
+    def predict(self, image_path: str) -> str:
+        """Return a chess move predicted from an image."""
+        return "d4"
+
+
+model = MoveModel()
+
+
 def process_move(image_path: str) -> str:
-    """Placeholder OCR logic."""
-    return "e2e4"
+    """Return the move predicted by the current model."""
+    return model.predict(image_path)
 
 
 def main() -> None:

--- a/backend_ia/tests/test_main.py
+++ b/backend_ia/tests/test_main.py
@@ -7,4 +7,4 @@ from service.main import process_move
 
 
 def test_process_move():
-    assert process_move('dummy.png') == 'e2e4'
+    assert process_move("dummy_path") == "d4"


### PR DESCRIPTION
## Summary
- provide `MoveModel` placeholder with train/save/load stubs returning fixed move `d4`
- drop OCR dependencies and simplify tests to match placeholder behaviour
- reopen TODO for future OCR pipeline work

## Testing
- `cd backend_ia && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68975bfb4aec832e947287e9401320ae