### PR TITLE
Define inter-service analysis API

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,7 @@
 
 - [x] Implement authentication in `backend_site`.
 - [x] Add OCR processing pipeline in `backend_ia`.
-- [ ] Define API between `backend_site` and `backend_ia` for submitting sheet
+- [x] Define API between `backend_site` and `backend_ia` for submitting sheet
       images, game state, and legal moves and returning candidate moves with
       confidence scores.
 - [ ] Build Vue components for uploading scans and reviewing moves.

--- a/backend_ia/requirements.txt
+++ b/backend_ia/requirements.txt
@@ -1,1 +1,2 @@
+fastapi
 pytest

--- a/backend_ia/service/main.py
+++ b/backend_ia/service/main.py
@@ -1,13 +1,39 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
 from .model import MoveModel
 from .ocr import OcrPipeline
 
+app = FastAPI()
 model = MoveModel()
 pipeline = OcrPipeline(model)
+
+
+class AnalysisRequest(BaseModel):
+    image: str
+    state: str
+    legal_moves: list[str]
+
+
+class MoveCandidate(BaseModel):
+    move: str
+    confidence: float
+
+
+class AnalysisResponse(BaseModel):
+    candidates: list[MoveCandidate]
 
 
 def process_move(image_path: str) -> str:
     """Return the move predicted by the OCR pipeline."""
     return pipeline.run(image_path)
+
+
+@app.post("/analyze", response_model=AnalysisResponse)
+def analyze(data: AnalysisRequest) -> AnalysisResponse:
+    move = process_move(data.image)
+    candidate = MoveCandidate(move=move, confidence=1.0)
+    return AnalysisResponse(candidates=[candidate])
 
 
 def main() -> None:
@@ -16,3 +42,4 @@ def main() -> None:
 
 if __name__ == "__main__":
     main()
+

--- a/backend_ia/tests/test_main.py
+++ b/backend_ia/tests/test_main.py
@@ -3,8 +3,18 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from service.main import process_move
+from fastapi.testclient import TestClient
+
+from service.main import app, process_move
 
 
 def test_process_move():
     assert process_move("dummy_path") == "d4"
+
+
+def test_analyze_endpoint():
+    client = TestClient(app)
+    payload = {"image": "path", "state": "fen", "legal_moves": ["e4", "d4"]}
+    response = client.post("/analyze", json=payload)
+    assert response.status_code == 200
+    assert response.json() == {"candidates": [{"move": "d4", "confidence": 1.0}]}

--- a/backend_site/tests/test_analyze.py
+++ b/backend_site/tests/test_analyze.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import importlib
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from fastapi.testclient import TestClient
+
+
+def test_analyze(monkeypatch):
+    monkeypatch.setenv("IA_SERVICE_URL", "http://ia-service:1234")
+    import app.main as m
+    importlib.reload(m)
+
+    called = {}
+
+    def fake_post(url, json):
+        called["url"] = url
+
+        class Dummy:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict:
+                return {"candidates": [{"move": "d4", "confidence": 0.9}]}
+
+        return Dummy()
+
+    monkeypatch.setattr(m.httpx, "post", fake_post)
+    client = TestClient(m.app)
+    payload = {"image": "img", "state": "fen", "legal_moves": ["e4"]}
+    response = client.post("/analyze", json=payload)
+    assert called["url"] == "http://ia-service:1234/analyze"
+    assert response.json() == {"candidates": [{"move": "d4", "confidence": 0.9}]}
+


### PR DESCRIPTION
## Summary
- add FastAPI endpoint in backend_ia for move analysis
- expose analyze endpoint in backend_site that forwards requests to backend_ia
- allow IA service URL to be configured via environment variable
- mark API integration task complete and cover with tests

## Testing
- `cd backend_site && pytest`
- `cd ../backend_ia && pytest`


------
https://chatgpt.com/codex/tasks/task_e_68976b3fc8c4832ebb665d8daf5d363d